### PR TITLE
Added indexer:lock-all command

### DIFF
--- a/Console/Command/IndexerLockAll.php
+++ b/Console/Command/IndexerLockAll.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Element119\IndexerDeployConfig\Console\Command;
 
+use InvalidArgumentException;
 use Magento\Framework\App\DeploymentConfig\Writer;
 use Magento\Framework\App\ObjectManagerFactory;
 use Magento\Framework\Config\File\ConfigFilePool;
 use Magento\Indexer\Console\Command\AbstractIndexerCommand;
+use Magento\Indexer\Console\Command\IndexerSetModeCommand;
 use Magento\Indexer\Model\Indexer\CollectionFactory;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -34,8 +36,6 @@ class IndexerLockAll extends AbstractIndexerCommand
         $this->configWriter = $configWriter;
     }
 
-    public const MODE_OPTION = 'mode';
-
     /**
      * {@inheritdoc}
      */
@@ -43,7 +43,19 @@ class IndexerLockAll extends AbstractIndexerCommand
         InputInterface $input,
         OutputInterface $output
     ) {
-        $mode = $input->getOption(self::MODE_OPTION);
+        $mode = $input->getOption(IndexerSetModeCommand::INPUT_KEY_MODE);
+
+        $modes = [
+            IndexerSetModeCommand::INPUT_KEY_SCHEDULE,
+            IndexerSetModeCommand::INPUT_KEY_REALTIME
+        ];
+
+        if (!is_null($mode) && !in_array($mode, $modes, true))
+        {
+            throw new InvalidArgumentException(
+                'Passed mode must be one of: ' . implode(', ', $modes)
+            );
+        }
 
         $indexerConfig = [];
 
@@ -64,7 +76,7 @@ class IndexerLockAll extends AbstractIndexerCommand
         $this->setName('indexer:lock-all');
         $this->setDescription('Lock all indexers (default locks to Update on Schedule)');
         $this->setDefinition([
-            new InputOption(self::MODE_OPTION, 'm', InputArgument::OPTIONAL, 'Mode', 'schedule'),
+            new InputOption(IndexerSetModeCommand::INPUT_KEY_MODE, 'm', InputArgument::OPTIONAL, 'Mode', null),
         ]);
         parent::configure();
     }

--- a/Console/Command/IndexerLockAll.php
+++ b/Console/Command/IndexerLockAll.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Element119\IndexerDeployConfig\Console\Command;
+
+use Magento\Framework\App\DeploymentConfig\Writer;
+use Magento\Framework\App\ObjectManagerFactory;
+use Magento\Framework\Config\File\ConfigFilePool;
+use Magento\Indexer\Console\Command\AbstractIndexerCommand;
+use Magento\Indexer\Model\Indexer\CollectionFactory;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class IndexerLockAll extends AbstractIndexerCommand
+{
+    private \Magento\Framework\App\DeploymentConfig\Writer $configWriter;
+
+    /**
+     * Constructor.
+     *
+     * @param ObjectManagerFactory   $objectManagerFactory
+     * @param Writer                 $configWriter
+     * @param CollectionFactory|null $collectionFactory
+     */
+    public function __construct(
+        ObjectManagerFactory $objectManagerFactory,
+        \Magento\Framework\App\DeploymentConfig\Writer $configWriter,
+        \Magento\Indexer\Model\Indexer\CollectionFactory $collectionFactory = null
+    ) {
+        parent::__construct($objectManagerFactory, $collectionFactory);
+        $this->configWriter = $configWriter;
+    }
+
+    public const MODE_OPTION = 'mode';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(
+        InputInterface $input,
+        OutputInterface $output
+    ) {
+        $mode = $input->getOption(self::MODE_OPTION);
+
+        $indexerConfig = [];
+
+        foreach ($this->getAllIndexers() as $indexer) {
+            $indexerConfig[$mode][] = $indexer->getIndexerId();
+        }
+
+        $this->configWriter->saveConfig([ConfigFilePool::APP_CONFIG => ['indexers' => $indexerConfig]], true);
+
+        $output->writeln('All indexers have been locked to ' . ($mode === 'schedule' ? 'Update on Schedule' : 'Update on Save'));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setName('indexer:lock-all');
+        $this->setDescription('Lock all indexers (default locks to Update on Schedule)');
+        $this->setDefinition([
+            new InputOption(self::MODE_OPTION, 'm', InputArgument::OPTIONAL, 'Mode', 'schedule'),
+        ]);
+        parent::configure();
+    }
+}

--- a/Plugin/SetIndexerModeRealtime.php
+++ b/Plugin/SetIndexerModeRealtime.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Copyright © element119. All rights reserved.
+ * See LICENCE.txt for licence details.
+ */
+declare(strict_types=1);
+
+namespace Element119\IndexerDeployConfig\Plugin;
+
+use Element119\IndexerDeployConfig\Model\IndexerConfig;
+use Magento\Framework\Message\ManagerInterface as MessageManagerInterface;
+use Magento\Indexer\Console\Command\IndexerSetModeCommand as IndexerMode;
+use Magento\Indexer\Controller\Adminhtml\Indexer\MassChangelog;
+use Magento\Indexer\Controller\Adminhtml\Indexer\MassOnTheFly;
+use Magento\Indexer\Model\Indexer;
+
+class SetIndexerModeRealtime extends SetIndexerMode
+{
+    public function __construct(
+        IndexerConfig $indexerConfig,
+        MessageManagerInterface $messageManager,
+        string $indexerMode = ''
+    ) {
+        parent::__construct('save', $messageManager, $indexerMode);
+    }
+}

--- a/Plugin/SetIndexerModeSchedule.php
+++ b/Plugin/SetIndexerModeSchedule.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Copyright © element119. All rights reserved.
+ * See LICENCE.txt for licence details.
+ */
+declare(strict_types=1);
+
+namespace Element119\IndexerDeployConfig\Plugin;
+
+use Element119\IndexerDeployConfig\Model\IndexerConfig;
+use Magento\Framework\Message\ManagerInterface as MessageManagerInterface;
+use Magento\Indexer\Console\Command\IndexerSetModeCommand as IndexerMode;
+use Magento\Indexer\Controller\Adminhtml\Indexer\MassChangelog;
+use Magento\Indexer\Controller\Adminhtml\Indexer\MassOnTheFly;
+use Magento\Indexer\Model\Indexer;
+
+class SetIndexerModeSchedule extends SetIndexerMode
+{
+    public function __construct(
+        IndexerConfig $indexerConfig,
+        MessageManagerInterface $messageManager,
+        string $indexerMode = ''
+    ) {
+        parent::__construct('schedule', $messageManager, $indexerMode);
+    }
+}

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -8,22 +8,12 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <!-- Prevent Indexer Mode Changes from Save to Schedule -->
-    <virtualType name="setOnSaveIndexerMode" type="Element119\IndexerDeployConfig\Plugin\SetIndexerMode">
-        <arguments>
-            <argument name="indexerMode" xsi:type="string">save</argument>
-        </arguments>
-    </virtualType>
     <type name="Magento\Indexer\Controller\Adminhtml\Indexer\MassChangelog">
-        <plugin name="config_based_indexer_mode_mass_action_schedule" type="setOnSaveIndexerMode"/>
+        <plugin name="config_based_indexer_mode_mass_action_schedule" type="\Element119\IndexerDeployConfig\Plugin\SetIndexerModeRealtime"/>
     </type>
 
     <!-- Prevent Indexer Mode Changes from Schedule to Save -->
-    <virtualType name="setOnScheduleIndexerMode" type="Element119\IndexerDeployConfig\Plugin\SetIndexerMode">
-        <arguments>
-            <argument name="indexerMode" xsi:type="string">schedule</argument>
-        </arguments>
-    </virtualType>
     <type name="Magento\Indexer\Controller\Adminhtml\Indexer\MassOnTheFly">
-        <plugin name="config_based_indexer_mode_mass_action_save" type="setOnScheduleIndexerMode"/>
+        <plugin name="config_based_indexer_mode_mass_action_save" type="\Element119\IndexerDeployConfig\Plugin\SetIndexerModeSchedule"/>
     </type>
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -13,6 +13,14 @@
                 sortOrder="999999"/>
     </type>
 
+    <type name="Magento\Framework\Console\CommandList">
+        <arguments>
+            <argument name="commands" xsi:type="array">
+                <item name="IndexerLockAll" xsi:type="object">Element119\IndexerDeployConfig\Console\Command\IndexerLockAll</item>
+            </argument>
+        </arguments>
+    </type>
+
     <type name="Magento\Deploy\Model\DeploymentConfig\ImporterPool">
         <arguments>
             <argument name="importers" xsi:type="array">


### PR DESCRIPTION
```
bin/magento indexer:lock-all --help     
Description:
  Lock all indexers

Usage:
  indexer:lock-all [options]

Options:
  -m, --mode=MODE       Passing one of two modes (schedule, realtime) will lock all indexers to that mode
  -h, --help            Display this help message
  -q, --quiet           Do not output any message
  -V, --version         Display this application version
      --ansi            Force ANSI output
      --no-ansi         Disable ANSI output
  -n, --no-interaction  Do not ask any interactive question
  -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
```

```
$ bin/magento indexer:lock-all                                                 
Design Config Grid indexer has been locked to Update on Save
Customer Grid indexer has been locked to Update on Schedule
Category Products indexer has been locked to Update on Save
Product Categories indexer has been locked to Update on Schedule
Catalog Rule Product indexer has been locked to Update on Save
Product EAV indexer has been locked to Update on Schedule
Stock indexer has been locked to Update on Save
Product Price indexer has been locked to Update on Schedule
Catalog Product Rule indexer has been locked to Update on Save
Catalog Search indexer has been locked to Update on Schedule
ElasticSuite Category Indexing indexer has been locked to Update on Save
ElasticSuite Thesaurus Indexing indexer has been locked to Update on Schedule
```

```
$ bin/magento indexer:lock-all --mode schedule 
Design Config Grid indexer has been locked to Update on Schedule
Customer Grid indexer has been locked to Update on Schedule
Category Products indexer has been locked to Update on Schedule
Product Categories indexer has been locked to Update on Schedule
Catalog Rule Product indexer has been locked to Update on Schedule
Product EAV indexer has been locked to Update on Schedule
Stock indexer has been locked to Update on Schedule
Product Price indexer has been locked to Update on Schedule
Catalog Product Rule indexer has been locked to Update on Schedule
Catalog Search indexer has been locked to Update on Schedule
ElasticSuite Category Indexing indexer has been locked to Update on Schedule
ElasticSuite Thesaurus Indexing indexer has been locked to Update on Schedule
```

```
$ bin/magento indexer:lock-all --mode realtime
Design Config Grid indexer has been locked to Update on Save
Customer Grid indexer has been locked to Update on Save
Category Products indexer has been locked to Update on Save
Product Categories indexer has been locked to Update on Save
Catalog Rule Product indexer has been locked to Update on Save
Product EAV indexer has been locked to Update on Save
Stock indexer has been locked to Update on Save
Product Price indexer has been locked to Update on Save
Catalog Product Rule indexer has been locked to Update on Save
Catalog Search indexer has been locked to Update on Save
ElasticSuite Category Indexing indexer has been locked to Update on Save
ElasticSuite Thesaurus Indexing indexer has been locked to Update on Save
```

```
$ bin/magento indexer:lock-all --mode save    

In IndexerLockAll.php line 55:
                                                  
  Passed mode must be one of: schedule, realtime  
                                                  

indexer:lock-all [-m|--mode MODE]
```