### PR TITLE
WIP: Add lock flag to set mode

### DIFF
--- a/Console/Command/IndexerLockAll.php
+++ b/Console/Command/IndexerLockAll.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Element119\IndexerDeployConfig\Console\Command;
 
+use InvalidArgumentException;
 use Magento\Framework\App\DeploymentConfig\Writer;
 use Magento\Framework\App\ObjectManagerFactory;
 use Magento\Framework\Config\File\ConfigFilePool;
 use Magento\Indexer\Console\Command\AbstractIndexerCommand;
+use Magento\Indexer\Console\Command\IndexerSetModeCommand;
 use Magento\Indexer\Model\Indexer\CollectionFactory;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -34,8 +36,6 @@ class IndexerLockAll extends AbstractIndexerCommand
         $this->configWriter = $configWriter;
     }
 
-    public const MODE_OPTION = 'mode';
-
     /**
      * {@inheritdoc}
      */
@@ -43,7 +43,19 @@ class IndexerLockAll extends AbstractIndexerCommand
         InputInterface $input,
         OutputInterface $output
     ) {
-        $mode = $input->getOption(self::MODE_OPTION);
+        $mode = $input->getOption(IndexerSetModeCommand::INPUT_KEY_MODE);
+
+        $modes = [
+            IndexerSetModeCommand::INPUT_KEY_SCHEDULE,
+            IndexerSetModeCommand::INPUT_KEY_REALTIME
+        ];
+
+        if (!is_null($mode) && !in_array($mode, $modes, true))
+        {
+            throw new InvalidArgumentException(
+                'Passed mode must be one of: ' . implode(', ', $modes)
+            );
+        }
 
         $indexerConfig = [];
 
@@ -64,7 +76,7 @@ class IndexerLockAll extends AbstractIndexerCommand
         $this->setName('indexer:lock-all');
         $this->setDescription('Lock all indexers (default locks to Update on Schedule)');
         $this->setDefinition([
-            new InputOption(self::MODE_OPTION, 'm', InputArgument::OPTIONAL, 'Mode', 'schedule'),
+            new InputOption(IndexerSetModeCommand::INPUT_KEY_MODE, 'm', InputArgument::OPTIONAL, 'Mode', null),
         ]);
         parent::configure();
     }

--- a/Console/Command/IndexerLockAll.php
+++ b/Console/Command/IndexerLockAll.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Element119\IndexerDeployConfig\Console\Command;
+
+use Magento\Framework\App\DeploymentConfig\Writer;
+use Magento\Framework\App\ObjectManagerFactory;
+use Magento\Framework\Config\File\ConfigFilePool;
+use Magento\Indexer\Console\Command\AbstractIndexerCommand;
+use Magento\Indexer\Model\Indexer\CollectionFactory;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class IndexerLockAll extends AbstractIndexerCommand
+{
+    private \Magento\Framework\App\DeploymentConfig\Writer $configWriter;
+
+    /**
+     * Constructor.
+     *
+     * @param ObjectManagerFactory   $objectManagerFactory
+     * @param Writer                 $configWriter
+     * @param CollectionFactory|null $collectionFactory
+     */
+    public function __construct(
+        ObjectManagerFactory $objectManagerFactory,
+        \Magento\Framework\App\DeploymentConfig\Writer $configWriter,
+        \Magento\Indexer\Model\Indexer\CollectionFactory $collectionFactory = null
+    ) {
+        parent::__construct($objectManagerFactory, $collectionFactory);
+        $this->configWriter = $configWriter;
+    }
+
+    public const MODE_OPTION = 'mode';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(
+        InputInterface $input,
+        OutputInterface $output
+    ) {
+        $mode = $input->getOption(self::MODE_OPTION);
+
+        $indexerConfig = [];
+
+        foreach ($this->getAllIndexers() as $indexer) {
+            $indexerConfig[$mode][] = $indexer->getIndexerId();
+        }
+
+        $this->configWriter->saveConfig([ConfigFilePool::APP_CONFIG => ['indexers' => $indexerConfig]], true);
+
+        $output->writeln('All indexers have been locked to ' . ($mode === 'schedule' ? 'Update on Schedule' : 'Update on Save'));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setName('indexer:lock-all');
+        $this->setDescription('Lock all indexers (default locks to Update on Schedule)');
+        $this->setDefinition([
+            new InputOption(self::MODE_OPTION, 'm', InputArgument::OPTIONAL, 'Mode', 'schedule'),
+        ]);
+        parent::configure();
+    }
+}

--- a/Console/Command/IndexerSetModeCommand.php
+++ b/Console/Command/IndexerSetModeCommand.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Element119\IndexerDeployConfig\Console\Command;
+
+use Element119\IndexerDeployConfig\Model\IndexerConfig;
+use Magento\Framework\App\DeploymentConfig\Writer;
+use Magento\Framework\App\ObjectManagerFactory;
+use Magento\Framework\Config\File\ConfigFilePool;
+use Magento\Indexer\Console\Command\IndexerSetModeCommand as CoreIndexerSetModeCommand;
+use Magento\Indexer\Model\Indexer\CollectionFactory;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class IndexerSetModeCommand extends CoreIndexerSetModeCommand
+{
+    const INPUT_KEY_LOCK = 'lock';
+
+    private Writer $configWriter;
+
+    private IndexerConfig $indexerConfig;
+
+    /**
+     * Constructor.
+     *
+     * @param ObjectManagerFactory   $objectManagerFactory
+     * @param Writer                 $configWriter
+     * @param IndexerConfig          $indexerConfig
+     * @param CollectionFactory|null $collectionFactory
+     */
+    public function __construct(
+        ObjectManagerFactory $objectManagerFactory,
+        Writer $configWriter,
+        IndexerConfig $indexerConfig,
+        CollectionFactory $collectionFactory = null
+    ) {
+        parent::__construct($objectManagerFactory, $collectionFactory);
+        $this->configWriter = $configWriter;
+        $this->indexerConfig = $indexerConfig;
+    }
+
+    /**
+     * @return array
+     */
+    public function getInputList(): array
+    {
+        $modeOptions[] = new InputOption(
+            self::INPUT_KEY_LOCK,
+            'l',
+            InputOption::VALUE_NONE,
+            'Lock the indexer(s) in the config file'
+        );
+        return array_merge($modeOptions, parent::getInputList());
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $result = parent::execute($input, $output);
+
+        $indexers = $this->getIndexers($input);
+        $indexerConfig = $this->indexerConfig->getIndexerConfig();
+        $mode = $input->getArgument(self::INPUT_KEY_MODE);
+
+        if (!isset($indexerConfig['realtime'])) {
+            $indexerConfig['realtime'] = [];
+        }
+        if (!isset($indexerConfig['schedule'])) {
+            $indexerConfig['schedule'] = [];
+        }
+
+        foreach ($indexers as $indexer) {
+            if (($key = array_search($indexer->getId(), $indexerConfig['realtime'], true)) !== false) {
+                unset($indexerConfig['realtime'][$key]);
+            }
+            if (($key = array_search($indexer->getId(), $indexerConfig['schedule'], true)) !== false) {
+                unset($indexerConfig['realtime'][$key]);
+            }
+            $indexerConfig[$mode][] = $indexer->getId();
+        }
+
+        $this->configWriter->saveConfig([ConfigFilePool::APP_CONFIG => ['indexers' => $indexerConfig]], true);
+
+        return $result;
+    }
+}

--- a/Plugin/SetIndexerModeRealtime.php
+++ b/Plugin/SetIndexerModeRealtime.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Copyright © element119. All rights reserved.
+ * See LICENCE.txt for licence details.
+ */
+declare(strict_types=1);
+
+namespace Element119\IndexerDeployConfig\Plugin;
+
+use Element119\IndexerDeployConfig\Model\IndexerConfig;
+use Magento\Framework\Message\ManagerInterface as MessageManagerInterface;
+use Magento\Indexer\Console\Command\IndexerSetModeCommand as IndexerMode;
+use Magento\Indexer\Controller\Adminhtml\Indexer\MassChangelog;
+use Magento\Indexer\Controller\Adminhtml\Indexer\MassOnTheFly;
+use Magento\Indexer\Model\Indexer;
+
+class SetIndexerModeRealtime extends SetIndexerMode
+{
+    public function __construct(
+        IndexerConfig $indexerConfig,
+        MessageManagerInterface $messageManager,
+        string $indexerMode = ''
+    ) {
+        parent::__construct('save', $messageManager, $indexerMode);
+    }
+}

--- a/Plugin/SetIndexerModeSchedule.php
+++ b/Plugin/SetIndexerModeSchedule.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Copyright © element119. All rights reserved.
+ * See LICENCE.txt for licence details.
+ */
+declare(strict_types=1);
+
+namespace Element119\IndexerDeployConfig\Plugin;
+
+use Element119\IndexerDeployConfig\Model\IndexerConfig;
+use Magento\Framework\Message\ManagerInterface as MessageManagerInterface;
+use Magento\Indexer\Console\Command\IndexerSetModeCommand as IndexerMode;
+use Magento\Indexer\Controller\Adminhtml\Indexer\MassChangelog;
+use Magento\Indexer\Controller\Adminhtml\Indexer\MassOnTheFly;
+use Magento\Indexer\Model\Indexer;
+
+class SetIndexerModeSchedule extends SetIndexerMode
+{
+    public function __construct(
+        IndexerConfig $indexerConfig,
+        MessageManagerInterface $messageManager,
+        string $indexerMode = ''
+    ) {
+        parent::__construct('schedule', $messageManager, $indexerMode);
+    }
+}

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -8,22 +8,12 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <!-- Prevent Indexer Mode Changes from Save to Schedule -->
-    <virtualType name="setOnSaveIndexerMode" type="Element119\IndexerDeployConfig\Plugin\SetIndexerMode">
-        <arguments>
-            <argument name="indexerMode" xsi:type="string">save</argument>
-        </arguments>
-    </virtualType>
     <type name="Magento\Indexer\Controller\Adminhtml\Indexer\MassChangelog">
-        <plugin name="config_based_indexer_mode_mass_action_schedule" type="setOnSaveIndexerMode"/>
+        <plugin name="config_based_indexer_mode_mass_action_schedule" type="\Element119\IndexerDeployConfig\Plugin\SetIndexerModeRealtime"/>
     </type>
 
     <!-- Prevent Indexer Mode Changes from Schedule to Save -->
-    <virtualType name="setOnScheduleIndexerMode" type="Element119\IndexerDeployConfig\Plugin\SetIndexerMode">
-        <arguments>
-            <argument name="indexerMode" xsi:type="string">schedule</argument>
-        </arguments>
-    </virtualType>
     <type name="Magento\Indexer\Controller\Adminhtml\Indexer\MassOnTheFly">
-        <plugin name="config_based_indexer_mode_mass_action_save" type="setOnScheduleIndexerMode"/>
+        <plugin name="config_based_indexer_mode_mass_action_save" type="\Element119\IndexerDeployConfig\Plugin\SetIndexerModeSchedule"/>
     </type>
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -13,6 +13,8 @@
                 sortOrder="999999"/>
     </type>
 
+    <preference for="Magento\Indexer\Console\Command\IndexerSetModeCommand" type="\Element119\IndexerDeployConfig\Console\Command\IndexerSetModeCommand" />
+
     <type name="Magento\Framework\Console\CommandList">
         <arguments>
             <argument name="commands" xsi:type="array">

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -13,6 +13,14 @@
                 sortOrder="999999"/>
     </type>
 
+    <type name="Magento\Framework\Console\CommandList">
+        <arguments>
+            <argument name="commands" xsi:type="array">
+                <item name="IndexerLockAll" xsi:type="object">Element119\IndexerDeployConfig\Console\Command\IndexerLockAll</item>
+            </argument>
+        </arguments>
+    </type>
+
     <type name="Magento\Deploy\Model\DeploymentConfig\ImporterPool">
         <arguments>
             <argument name="importers" xsi:type="array">


### PR DESCRIPTION
Did some preliminary work but contains a bug;

`bin/magento indexer:set-mode realtime design_config_grid -l`

So far so good:

```
diff --git a/app/etc/config.php b/app/etc/config.php
index 394877a..42a851e 100644
--- a/app/etc/config.php
+++ b/app/etc/config.php
@@ -426,7 +426,7 @@ return [
             'elasticsuite_thesaurus'
         ],
         'realtime' => [
-
+            'design_config_grid'
         ]
     ]
 ];
```

However, on running it again, the code unsets the value if it exists, and then re-adds it, causing an associative array to appear;

```
bin/magento indexer:set-mode realtime design_config_grid -l
```

```
diff --git a/app/etc/config.php b/app/etc/config.php
index 394877a..43553e8 100644
--- a/app/etc/config.php
+++ b/app/etc/config.php
@@ -426,7 +426,7 @@ return [
             'elasticsuite_thesaurus'
         ],
         'realtime' => [
-
+            1 => 'design_config_grid'
         ]
     ]
 ];

```

Drawing a blank on how to avoid this..