### PR TITLE
Update IndexerConfigurationException.php

### DIFF
--- a/Exception/IndexerConfigurationException.php
+++ b/Exception/IndexerConfigurationException.php
@@ -16,7 +16,7 @@ class IndexerConfigurationException extends ConfigurationMismatchException
     /**
      * @param Phrase|null $phrase
      * @param Exception|null $cause
-     * @param $code
+     * @param int $code
      */
     public function __construct(
         Phrase $phrase = null,


### PR DESCRIPTION
```
Interception cache generation... 6/9 [=========>----]  66% 52 secs 614.0 MiBErrors during compilation:
	Element119\IndexerDeployConfig\Exception\IndexerConfigurationException
		Incompatible argument type: Required type: int. Actual type: \Element119\IndexerDeployConfig\Exception\code; File: 
```

This fixed the di compilation for us on EE 2.4.3 🤷