### PR TITLE
Add Additional Measure to Ensure Indexers Remain in Locked Mode

### DIFF
--- a/Cron/SetIndexerMode.php
+++ b/Cron/SetIndexerMode.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Copyright © element119. All rights reserved.
+ * See LICENCE.txt for licence details.
+ */
+declare(strict_types=1);
+
+namespace Element119\IndexerDeployConfig\Cron;
+
+use Element119\IndexerDeployConfig\Model\IndexerConfig;
+use Element119\IndexerDeployConfig\Scope\ModuleConfig;
+use Magento\Indexer\Console\Command\IndexerSetModeCommand as IndexerMode;
+use Magento\Indexer\Model\Indexer\CollectionFactory as IndexerCollectionFactory;
+use Magento\Indexer\Model\Indexer;
+
+class SetIndexerMode
+{
+    /** @var IndexerConfig */
+    private IndexerConfig $indexerConfig;
+
+    /** @var ModuleConfig */
+    private ModuleConfig $moduleConfig;
+
+    /** @var IndexerCollectionFactory */
+    private IndexerCollectionFactory $indexerCollectionFactory;
+
+    /**
+     * @param IndexerConfig $indexerConfig
+     * @param ModuleConfig $moduleConfig
+     * @param IndexerCollectionFactory $indexerCollectionFactory
+     */
+    public function __construct(
+        IndexerConfig $indexerConfig,
+        ModuleConfig $moduleConfig,
+        IndexerCollectionFactory $indexerCollectionFactory
+    ) {
+        $this->indexerConfig = $indexerConfig;
+        $this->moduleConfig = $moduleConfig;
+        $this->indexerCollectionFactory = $indexerCollectionFactory;
+    }
+
+    /**
+     * Ensure indexers are in the mode they are configured to be locked to.
+     *
+     * Can be disabled in the admin:
+     * Stores -> Settings -> Configuration -> Advanced -> System -> Indexer Mode Locking -> Enable Cron Fallback -> No
+     *
+     * @return void
+     */
+    public function execute(): void
+    {
+        if (!$this->moduleConfig->isCronFallbackEnabled()) {
+            return; // fallback disabled, nothing to do
+        }
+
+        if (!($indexerConfig = $this->indexerConfig->getFlatIndexerConfig())) {
+            return; // indexers are not locked, nothing to do
+        }
+
+        /** @var Indexer[] $allIndexers */
+        $allIndexers = $this->indexerCollectionFactory->create()->getItems();
+
+        foreach ($allIndexers as $indexer) {
+            foreach ($indexerConfig as $indexerId => $lockedMode) {
+                if ($indexer->getId() !== $indexerId) {
+                    continue; // ensure we're looking at the same indexer in both loops
+                }
+
+                $indexerMode = $indexer->isScheduled()
+                    ? IndexerMode::INPUT_KEY_SCHEDULE
+                    : IndexerMode::INPUT_KEY_REALTIME;
+
+                if ($indexerMode !== $lockedMode) {
+                    $indexer->setScheduled($lockedMode === IndexerMode::INPUT_KEY_SCHEDULE);
+                }
+            }
+        }
+    }
+}

--- a/Cron/SetIndexerMode.php
+++ b/Cron/SetIndexerMode.php
@@ -49,12 +49,10 @@ class SetIndexerMode
      */
     public function execute(): void
     {
-        if (!$this->moduleConfig->isCronFallbackEnabled()) {
-            return; // fallback disabled, nothing to do
-        }
-
-        if (!($indexerConfig = $this->indexerConfig->getFlatIndexerConfig())) {
-            return; // indexers are not locked, nothing to do
+        if (!$this->moduleConfig->isCronFallbackEnabled()
+            || !($indexerConfig = $this->indexerConfig->getFlatIndexerConfig())
+        ) {
+            return; // fallback disabled or indexers are not locked, nothing to do
         }
 
         /** @var Indexer[] $allIndexers */

--- a/Model/IndexerConfig.php
+++ b/Model/IndexerConfig.php
@@ -10,12 +10,18 @@ namespace Element119\IndexerDeployConfig\Model;
 use Magento\Framework\App\DeploymentConfig;
 use Magento\Framework\Exception\FileSystemException;
 use Magento\Framework\Exception\RuntimeException;
+use Magento\Indexer\Console\Command\IndexerSetModeCommand as IndexerMode;
+use Magento\Indexer\Model\Indexer\CollectionFactory as IndexerCollectionFactory;
+use Magento\Indexer\Model\Indexer;
 use Psr\Log\LoggerInterface;
 
 class IndexerConfig
 {
     /** @var DeploymentConfig */
     private DeploymentConfig $deploymentConfig;
+
+    /** @var IndexerCollectionFactory */
+    private IndexerCollectionFactory $indexerCollectionFactory;
 
     /** @var LoggerInterface */
     private LoggerInterface $logger;
@@ -26,15 +32,21 @@ class IndexerConfig
     /** @var array */
     private array $flatIndexerConfig = [];
 
+    /** @var array */
+    private array $viewIdToIndexerIdMap = [];
+
     /**
      * @param DeploymentConfig $deploymentConfig
+     * @param IndexerCollectionFactory $indexerCollectionFactory
      * @param LoggerInterface $logger
      */
     public function __construct(
         DeploymentConfig $deploymentConfig,
+        IndexerCollectionFactory $indexerCollectionFactory,
         LoggerInterface $logger
     ) {
         $this->deploymentConfig = $deploymentConfig;
+        $this->indexerCollectionFactory = $indexerCollectionFactory;
         $this->logger = $logger;
     }
 
@@ -77,6 +89,47 @@ class IndexerConfig
         }
 
         return $this->flatIndexerConfig;
+    }
+
+    /**
+     * Determine whether a given indexer ID should be locked to a particular mode.
+     *
+     * @param string $indexerId
+     * @return bool
+     */
+    public function isIndexerLocked(string $indexerId): bool
+    {
+        return array_key_exists($indexerId, $this->getFlatIndexerConfig());
+    }
+
+    /**
+     * Map view ID to indexer ID.
+     *
+     * @return array
+     */
+    public function getViewIdToIndexerIdMap(): array
+    {
+        if (!$this->viewIdToIndexerIdMap) {
+            /** @var Indexer $indexer */
+            foreach ($this->indexerCollectionFactory->create()->getItems() as $indexer) {
+                $this->viewIdToIndexerIdMap[$indexer->getViewId()] = $indexer->getId();
+            }
+        }
+
+        return $this->viewIdToIndexerIdMap;
+    }
+
+    /**
+     * Get the indexer ID for the given view ID.
+     *
+     * @param string|null $viewId
+     * @return string
+     */
+    public function getIndexerIdForViewId(?string $viewId): string
+    {
+        $map = $this->getViewIdToIndexerIdMap();
+
+        return array_key_exists($viewId, $map) ? $map[$viewId] : '';
     }
 
     /**

--- a/Model/IndexerConfig.php
+++ b/Model/IndexerConfig.php
@@ -23,6 +23,9 @@ class IndexerConfig
     /** @var array */
     private array $indexerConfig = [];
 
+    /** @var array */
+    private array $flatIndexerConfig = [];
+
     /**
      * @param DeploymentConfig $deploymentConfig
      * @param LoggerInterface $logger
@@ -51,6 +54,29 @@ class IndexerConfig
         }
 
         return $this->indexerConfig;
+    }
+
+    /**
+     * Get indexer config as indexerId => lockedMode pairs.
+     *
+     * @return array
+     */
+    public function getFlatIndexerConfig(): array
+    {
+        if (!$this->flatIndexerConfig) {
+            $flatIndexerConfig = [];
+            $indexerConfig = $this->getIndexerConfig();
+
+            foreach ($indexerConfig as $mode => $indexers) {
+                foreach ($indexers as $indexer) {
+                    $flatIndexerConfig[$indexer] = $mode;
+                }
+            }
+
+            $this->flatIndexerConfig = $flatIndexerConfig;
+        }
+
+        return $this->flatIndexerConfig;
     }
 
     /**

--- a/Model/IndexerConfig.php
+++ b/Model/IndexerConfig.php
@@ -20,6 +20,9 @@ class IndexerConfig
     /** @var LoggerInterface */
     private LoggerInterface $logger;
 
+    /** @var array */
+    private array $indexerConfig = [];
+
     /**
      * @param DeploymentConfig $deploymentConfig
      * @param LoggerInterface $logger
@@ -39,13 +42,15 @@ class IndexerConfig
      */
     public function getIndexerConfig(): array
     {
-        try {
-            return $this->deploymentConfig->get('indexers') ?? [];
-        } catch (FileSystemException | RunTimeException $e) {
-            $this->logger->error(__('Could not load indexer configuration from app/etc/config.php'));
-
-            return [];
+        if (!$this->indexerConfig) {
+            try {
+                $this->indexerConfig = $this->deploymentConfig->get('indexers');
+            } catch (FileSystemException|RunTimeException $e) {
+                $this->logger->error(__('Could not load indexer configuration from app/etc/config.php'));
+            }
         }
+
+        return $this->indexerConfig;
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -107,6 +107,15 @@ Coming soon...
 
 <br>
 
+### Indexer Mode Locking Cron Fallback
+A new system configuration option allows you to enable a cron job that will ensure indexers are in the mode they are
+supposed to be in, according to deployment config. This option can be found in `Stores -> Configuration -> Advanced ->
+System -> Indexer Mode Locking`.
+
+![indexer-mode-locking-cron-config](https://user-images.githubusercontent.com/40261741/221367876-d04e812d-9628-4bb2-a335-8532dd27299e.png)
+
+<br>
+
 ### `indexer:lock-all` Command
 The module adds a new `indexer:lock-all` command that you can use to lock the indexer modes via the command line.
 

--- a/Scope/ModuleConfig.php
+++ b/Scope/ModuleConfig.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright © element119. All rights reserved.
+ * See LICENCE.txt for licence details.
+ */
+declare(strict_types=1);
+
+namespace Element119\IndexerDeployConfig\Scope;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+
+class ModuleConfig
+{
+    private const XML_PATH_CRON_FALLBACK_ENABLED = 'system/e119_indexer_deploy_config/cron_enable';
+
+    /** @var ScopeConfigInterface */
+    private ScopeConfigInterface $scopeConfig;
+
+    /**
+     * @param ScopeConfigInterface $scopeConfig
+     */
+    public function __construct(
+        ScopeConfigInterface $scopeConfig
+    ) {
+        $this->scopeConfig = $scopeConfig;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isCronFallbackEnabled(): bool
+    {
+        return $this->scopeConfig->isSetFlag(self::XML_PATH_CRON_FALLBACK_ENABLED);
+    }
+}

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -7,6 +7,13 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <!-- Ensure Indexer Mode Remains in the Mode Defined by Deploy Config -->
+    <type name="Magento\Framework\Mview\View\StateInterface">
+        <plugin name="config_based_indexer_mode"
+                type="Element119\IndexerDeployConfig\Plugin\SetIndexerMode"
+                sortOrder="999999"/>
+    </type>
+
     <!-- Prevent Indexer Mode Changes from Save to Schedule -->
     <type name="Magento\Indexer\Controller\Adminhtml\Indexer\MassChangelog">
         <plugin name="config_based_indexer_mode_mass_action_schedule"

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © element119. All rights reserved.
+ * See LICENCE.txt for licence details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
+    <system>
+        <section id="system">
+            <group id="e119_indexer_deploy_config"
+                   translate="label"
+                   type="text"
+                   sortOrder="1000"
+                   showInDefault="1"
+                   showInWebsite="0"
+                   showInStore="0">
+                <label>Indexer Mode Locking</label>
+                <field id="cron_enable"
+                       translate="label comment"
+                       type="select"
+                       sortOrder="10"
+                       showInDefault="1"
+                       showInWebsite="0"
+                       showInStore="0"
+                       canRestore="1">
+                    <label>Enable Cron Fallback</label>
+                    <comment>
+                        <![CDATA[
+                        Enable the cron job that ensures indexers are respecting their deployment config.
+                        <br>
+                        This is a fallback mechanism designed to catch unexpected behaviour that causes indexer modes to change.
+                        ]]>
+                    </comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+            </group>
+        </section>
+    </system>
+</config>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © element119. All rights reserved.
+ * See LICENCE.txt for licence details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
+    <default>
+        <system>
+            <e119_indexer_deploy_config>
+                <cron_enable>0</cron_enable>
+            </e119_indexer_deploy_config>
+        </system>
+    </default>
+</config>

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+<!--
+/**
+ * Copyright © element119. All rights reserved.
+ * See LICENCE.txt for licence details.
+ */
+ -->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
+    <group id="default">
+        <job name="indexer_deploy_config_fallback"
+             instance="Element119\IndexerDeployConfig\Cron\SetIndexerMode"
+             method="execute">
+            <schedule>* * * * *</schedule>
+        </job>
+    </group>
+</config>

--- a/etc/crontab/di.xml
+++ b/etc/crontab/di.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © element119. All rights reserved.
+ * See LICENCE.txt for licence details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <!-- Ensure Indexer Mode Remains in the Mode Defined by Deploy Config -->
+    <type name="Magento\Framework\Mview\View\StateInterface">
+        <plugin name="config_based_indexer_mode"
+                type="Element119\IndexerDeployConfig\Plugin\SetIndexerMode"
+                sortOrder="999999"/>
+    </type>
+</config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -7,7 +7,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
-    <type name="Magento\Indexer\Model\Indexer">
+    <type name="Magento\Framework\Mview\View\StateInterface">
         <plugin name="config_based_indexer_mode"
                 type="Element119\IndexerDeployConfig\Plugin\SetIndexerMode"
                 sortOrder="999999"/>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -7,12 +7,6 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
-    <type name="Magento\Framework\Mview\View\StateInterface">
-        <plugin name="config_based_indexer_mode"
-                type="Element119\IndexerDeployConfig\Plugin\SetIndexerMode"
-                sortOrder="999999"/>
-    </type>
-
     <type name="Magento\Framework\Console\CommandList">
         <arguments>
             <argument name="commands" xsi:type="array">

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © element119. All rights reserved.
+ * See LICENCE.txt for licence details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <!-- Ensure Indexer Mode Remains in the Mode Defined by Deploy Config -->
+    <type name="Magento\Framework\Mview\View\StateInterface">
+        <plugin name="config_based_indexer_mode"
+                type="Element119\IndexerDeployConfig\Plugin\SetIndexerMode"
+                sortOrder="999999"/>
+    </type>
+</config>

--- a/etc/graphql/di.xml
+++ b/etc/graphql/di.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © element119. All rights reserved.
+ * See LICENCE.txt for licence details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <!-- Ensure Indexer Mode Remains in the Mode Defined by Deploy Config -->
+    <type name="Magento\Framework\Mview\View\StateInterface">
+        <plugin name="config_based_indexer_mode"
+                type="Element119\IndexerDeployConfig\Plugin\SetIndexerMode"
+                sortOrder="999999"/>
+    </type>
+</config>

--- a/etc/webapi_rest/di.xml
+++ b/etc/webapi_rest/di.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © element119. All rights reserved.
+ * See LICENCE.txt for licence details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <!-- Ensure Indexer Mode Remains in the Mode Defined by Deploy Config -->
+    <type name="Magento\Framework\Mview\View\StateInterface">
+        <plugin name="config_based_indexer_mode"
+                type="Element119\IndexerDeployConfig\Plugin\SetIndexerMode"
+                sortOrder="999999"/>
+    </type>
+</config>

--- a/etc/webapi_soap/di.xml
+++ b/etc/webapi_soap/di.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © element119. All rights reserved.
+ * See LICENCE.txt for licence details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <!-- Ensure Indexer Mode Remains in the Mode Defined by Deploy Config -->
+    <type name="Magento\Framework\Mview\View\StateInterface">
+        <plugin name="config_based_indexer_mode"
+                type="Element119\IndexerDeployConfig\Plugin\SetIndexerMode"
+                sortOrder="999999"/>
+    </type>
+</config>


### PR DESCRIPTION
# Description
Resolves #8 

- Added a fallback cron that checks indexers are in the mode they should be, according to deploy config
    - Added system config to toggle this functionality on or off (default)
- Refactored the indexer plugin to target more appropriate functions to catch more cases of indexer modes being changed
- Added additional helper functions to the indexer config model to help with the above implementations
- Updates plugin configuration to exist in all non-global scopes
